### PR TITLE
Resolved build issues with Cordova 9

### DIFF
--- a/bin/lib/android.js
+++ b/bin/lib/android.js
@@ -3,14 +3,12 @@ var mappings = require("./mappings"),
 
 module.exports = function (context) {
 
-	var
-		req = context ? context.requireCordovaModule : require,
-		Q = require('q'),
+	var Q = require('q'),
 		path = require('path'),
 		ET = require('elementtree'),
 		cordova_lib = require('cordova-lib'),
 		ConfigParser = cordova_lib.configparser,
-		cordova_util = req('cordova-lib/src/cordova/util'),
+		cordova_util = require('cordova-lib/src/cordova/util'),
 		fs = require("./filesystem")(Q, require('fs'), path),
 		platforms = {};
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "bin": {
     "cordova-app-preferences-generator": "bin/build-app-settings.js"
   },
+  "dependencies": {
+    "cordova-lib": "^9.0.0"
+  },
   "devDependencies": {
     "cordova": ">=5.4.1",
     "elementtree": "^0.1.6",


### PR DESCRIPTION
1. There was a left over `requireCordovaModule` import in `android.js` that has been converted to `require`
2. `cordova-lib` has been added a project dependency